### PR TITLE
Adjust the copy in the auth dialog to remove commas

### DIFF
--- a/felt/ui/authorize.ui
+++ b/felt/ui/authorize.ui
@@ -53,7 +53,7 @@
      <item>
       <widget class="QLabel" name="label_login">
        <property name="text">
-        <string>Share, collaborate, and mark up your maps quickly and beautifully on the web using Felt.
+        <string>Share and markup your maps quickly and beautifully on the web using Felt.
 
 Log in or sign up to get started - it’s free!</string>
        </property>


### PR DESCRIPTION
Currently the commas in the text used on the Auth dialog do not render correctly on MacOS machines using the official (intel-based) Qgis 3.34 installer from https://www.qgis.org/en/site/forusers/download.html.

Current:
<img width="577" alt="Screenshot 2024-02-27 at 6 55 56 PM" src="https://github.com/felt/qgis-plugin/assets/20300/4558a589-1243-424f-9b1f-09150fd85537">

Expected:
<img width="575" alt="Screenshot 2024-02-27 at 6 56 08 PM" src="https://github.com/felt/qgis-plugin/assets/20300/a73a3dd7-02fa-4a24-b4fa-6d41c5a97f20">

This addresses the issue by simplifying the language to avoid needing commas.
