### PR TITLE
Github Actions: use semver compatible dev package version name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Build package
       run: |
-        qgis-plugin-ci package dev-${GITHUB_SHA}
+        qgis-plugin-ci package `git describe --tags`-dev
         mkdir tmp
-        unzip felt.dev-${GITHUB_SHA}.zip -d tmp
+        unzip felt.`git describe --tags`-dev.zip -d tmp
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
I noticed that current `main` is failing due to this error:

<img width="1045" alt="Screenshot 2024-03-01 at 11 56 38 AM" src="https://github.com/felt/qgis-plugin/assets/20300/55a2f95a-2386-435b-bdbe-3545a13abca1">

https://github.com/felt/qgis-plugin/actions/runs/8074572022/job/22060082131

Is this perhaps due to https://github.com/opengisch/qgis-plugin-ci/pull/251 ?

This PR includes a proposed fix, but there are likely many valid ways to fix this. Curious for your thoughts on the right approach @nyalldawson.