### PR TITLE
Update v2 upload interaction to match late-breaking changes

### DIFF
--- a/felt/core/map_uploader.py
+++ b/felt/core/map_uploader.py
@@ -494,9 +494,7 @@ class MapUploaderTask(QgsTask):
             if self.isCanceled():
                 return False
 
-            layer_id = upload_details.get('data', {}).get('attributes',
-                                                          {}).get(
-                'first_layer_id')
+            layer_id = upload_details.get('layer_id')
             if details.style and details.style.fsl is not None:
                 if not layer_id:
                     Logger.instance().log_error_json(

--- a/felt/core/s3_upload_parameters.py
+++ b/felt/core/s3_upload_parameters.py
@@ -50,28 +50,15 @@ class S3UploadParameters:
         """
         return S3UploadParameters(
             type=res.get('data', {}).get('type'),
-            aws_access_key_id=res.get('data', {}).get('attributes', {}).get(
-                'presigned_attributes', {}).get('AWSAccessKeyId'),
-            acl=res.get('data', {}).get('attributes', {}).get(
-                'presigned_attributes', {}).get('acl'),
-            key=res.get('data', {}).get('attributes', {}).get(
-                'presigned_attributes', {}).get('key'),
-            policy=res.get('data', {}).get('attributes', {}).get(
-                'presigned_attributes', {}).get('policy'),
-            signature=res.get('data', {}).get('attributes', {}).get(
-                'presigned_attributes', {}).get('signature'),
-            success_action_status=res.get('data', {}).get('attributes',
-                                                          {}).get(
-                'presigned_attributes', {}).get('success_action_status'),
-            x_amz_meta_features_flags=res.get('data', {}).get('attributes',
-                                                              {}).get(
-                'presigned_attributes', {}).get('x-amz-meta-feature-flags'),
-            x_amz_meta_file_count=res.get('data', {}).get('attributes',
-                                                          {}).get(
-                'presigned_attributes', {}).get('x-amz-meta-file-count'),
-            x_amz_security_token=res.get('data', {}).get('attributes',
-                                                         {}).get(
-                'presigned_attributes', {}).get('x-amz-security-token'),
-            url=res.get('data', {}).get('attributes', {}).get('url'),
-            layer_id=res.get('data', {}).get('attributes', {}).get('layer_id'),
+            aws_access_key_id=res.get('presigned_attributes', {}).get('AWSAccessKeyId'),
+            acl=res.get('presigned_attributes', {}).get('acl'),
+            key=res.get('presigned_attributes', {}).get('key'),
+            policy=res.get('presigned_attributes', {}).get('policy'),
+            signature=res.get('presigned_attributes', {}).get('signature'),
+            success_action_status=res.get('presigned_attributes', {}).get('success_action_status'),
+            x_amz_meta_features_flags=res.get('presigned_attributes', {}).get('x-amz-meta-feature-flags'),
+            x_amz_meta_file_count=res.get('presigned_attributes', {}).get('x-amz-meta-file-count'),
+            x_amz_security_token=res.get('presigned_attributes', {}).get('x-amz-security-token'),
+            url=res.get('url'),
+            layer_id=res.get('layer_id'),
         )

--- a/felt/core/s3_upload_parameters.py
+++ b/felt/core/s3_upload_parameters.py
@@ -50,15 +50,20 @@ class S3UploadParameters:
         """
         return S3UploadParameters(
             type=res.get('data', {}).get('type'),
-            aws_access_key_id=res.get('presigned_attributes', {}).get('AWSAccessKeyId'),
+            aws_access_key_id=res.get('presigned_attributes', {}).get(
+                'AWSAccessKeyId'),
             acl=res.get('presigned_attributes', {}).get('acl'),
             key=res.get('presigned_attributes', {}).get('key'),
             policy=res.get('presigned_attributes', {}).get('policy'),
             signature=res.get('presigned_attributes', {}).get('signature'),
-            success_action_status=res.get('presigned_attributes', {}).get('success_action_status'),
-            x_amz_meta_features_flags=res.get('presigned_attributes', {}).get('x-amz-meta-feature-flags'),
-            x_amz_meta_file_count=res.get('presigned_attributes', {}).get('x-amz-meta-file-count'),
-            x_amz_security_token=res.get('presigned_attributes', {}).get('x-amz-security-token'),
+            success_action_status=res.get('presigned_attributes', {}).get(
+                'success_action_status'),
+            x_amz_meta_features_flags=res.get('presigned_attributes', {}).get(
+                'x-amz-meta-feature-flags'),
+            x_amz_meta_file_count=res.get('presigned_attributes', {}).get(
+                'x-amz-meta-file-count'),
+            x_amz_security_token=res.get('presigned_attributes', {}).get(
+                'x-amz-security-token'),
             url=res.get('url'),
             layer_id=res.get('layer_id'),
         )


### PR DESCRIPTION
There's two parts here:

- Response values under `["data"]["attributes"]` have been promoted to the top of the response
- `first_layer_id` has been renamed `layer_id`

I went ahead and made the PR myself to get a plugin build I could test with