### PR TITLE
Forward all presigned_attributes instead of trying to choose which ones to forward

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         echo ${{ github.event.pull_request.head.sha }} | tee git_commit
         echo ${{ github.event.number }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: felt_plugin.${{ env.VERSION }}
         path: tmp

--- a/felt/core/s3_upload_parameters.py
+++ b/felt/core/s3_upload_parameters.py
@@ -8,7 +8,8 @@ from typing import Dict
 @dataclass
 class S3UploadParameters:
     """
-    Encapsulates parameters for uploading to S3, including all presigned attributes
+    Encapsulates parameters for uploading to S3, including all presigned
+    attributes
     """
 
     url: str
@@ -18,14 +19,16 @@ class S3UploadParameters:
 
     def to_form_fields(self) -> Dict:
         """
-        Returns all form fields including the presigned attributes required for the upload
+        Returns all form fields including the presigned attributes required
+        for the upload
         """
         return {**self._presigned_attributes}
 
     @staticmethod
     def from_json(res: Dict[str, str]) -> 'S3UploadParameters':
         """
-        Creates upload parameters from a JSON response, capturing all presigned attributes
+        Creates upload parameters from a JSON response, capturing all
+        presigned attributes
         """
         return S3UploadParameters(
             url=res.get('url'),

--- a/felt/core/s3_upload_parameters.py
+++ b/felt/core/s3_upload_parameters.py
@@ -1,69 +1,35 @@
 """
 Felt API s3 upload parameters
 """
-
 from dataclasses import dataclass
-from typing import (
-    Optional,
-    Dict
-)
+from typing import Dict
 
 
 @dataclass
 class S3UploadParameters:
     """
-    Encapsulates parameters for uploading to S3
+    Encapsulates parameters for uploading to S3, including all presigned attributes
     """
 
-    aws_access_key_id: Optional[str]
-    acl: Optional[str]
-    key: Optional[str]
-    policy: Optional[str]
-    signature: Optional[str]
-    success_action_status: Optional[str]
-    x_amz_meta_features_flags: Optional[str]
-    x_amz_meta_file_count: Optional[str]
-    x_amz_security_token: Optional[str]
-    url: Optional[str]
-    layer_id: Optional[str]
-    type: Optional[str]
+    url: str
+    layer_id: str
+    type: str
+    _presigned_attributes: Dict[str, str]
 
     def to_form_fields(self) -> Dict:
         """
-        Returns the form fields required for the upload
+        Returns all form fields including the presigned attributes required for the upload
         """
-        return {
-            'AWSAccessKeyId': self.aws_access_key_id,
-            'key': self.key,
-            'policy': self.policy,
-            'signature': self.signature,
-            'success_action_status': self.success_action_status,
-            'x-amz-meta-feature-flags': self.x_amz_meta_features_flags,
-            'x-amz-meta-file-count': self.x_amz_meta_file_count,
-            'x-amz-security-token': self.x_amz_security_token,
-        }
+        return {**self._presigned_attributes}
 
     @staticmethod
-    def from_json(res: str) -> 'S3UploadParameters':
+    def from_json(res: Dict[str, str]) -> 'S3UploadParameters':
         """
-        Creates upload parameters from a JSON string
+        Creates upload parameters from a JSON response, capturing all presigned attributes
         """
         return S3UploadParameters(
-            type=res.get('data', {}).get('type'),
-            aws_access_key_id=res.get('presigned_attributes', {}).get(
-                'AWSAccessKeyId'),
-            acl=res.get('presigned_attributes', {}).get('acl'),
-            key=res.get('presigned_attributes', {}).get('key'),
-            policy=res.get('presigned_attributes', {}).get('policy'),
-            signature=res.get('presigned_attributes', {}).get('signature'),
-            success_action_status=res.get('presigned_attributes', {}).get(
-                'success_action_status'),
-            x_amz_meta_features_flags=res.get('presigned_attributes', {}).get(
-                'x-amz-meta-feature-flags'),
-            x_amz_meta_file_count=res.get('presigned_attributes', {}).get(
-                'x-amz-meta-file-count'),
-            x_amz_security_token=res.get('presigned_attributes', {}).get(
-                'x-amz-security-token'),
             url=res.get('url'),
             layer_id=res.get('layer_id'),
+            type=res.get('data', {}).get('type'),
+            _presigned_attributes=res.get('presigned_attributes', {})
         )

--- a/felt/core/s3_upload_parameters.py
+++ b/felt/core/s3_upload_parameters.py
@@ -21,6 +21,8 @@ class S3UploadParameters:
         """
         Returns all form fields including the presigned attributes required
         for the upload
+        Presigned attributes must be returned in the same order they
+        appeared in the original JSON
         """
         return {**self._presigned_attributes}
 


### PR DESCRIPTION
With the switch to multi-region hosting, uploads from the QGIS plugin broke because we had to change some of the presigned attribute signature keys (specifically adding `x-amz-signature`). The expectation was that API callers would forward all presigned attributes, but the QGIS plugin tried to pick and choose the ones it thought were necessary. This change just tries to forward the whole block.

We're going to fix this here in the plugin, but we're simultaneously trying to build in some backwards compatibility on the Felt pipeline side so that people with un-upgraded plugins can still upload files (as long as they're talking to the us1 Felt region, which until this week, everyone was)

Test plan:
- With production plugin, try uploading a layer, see you'll get a connection error when trying to post to s3
- With this plugin, it'll work!