### PR TITLE
Add specific "paid plan required" error message

### DIFF
--- a/felt/core/api_client.py
+++ b/felt/core/api_client.py
@@ -49,6 +49,11 @@ class CreatedGroupDetails:
     ordering_key: Optional[int] = None
 
 
+class PaidPlanRequiredError(Exception):
+    """Raised when an API operation requires a paid plan"""
+    pass
+
+
 class FeltApiClient:
     """
     Client for the Felt API
@@ -511,6 +516,9 @@ class FeltApiClient:
             request,
             json.dumps(group_post_data).encode()
         )
+
+        if reply.error() == QNetworkReply.ContentAccessDenied:
+            raise PaidPlanRequiredError("Upload requires a paid plan")
 
         return [
             CreatedGroupDetails(

--- a/felt/gui/create_map_dialog.py
+++ b/felt/gui/create_map_dialog.py
@@ -538,16 +538,23 @@ class CreateMapDialog(QDialog, WIDGET):
                     self._map_title)
             )
 
-            error_message = \
-                self.tr('There was an error uploading this file, please '
-                        'contact <a href="mailto:support@felt.com">'
-                        'support@felt.com</a> '
-                        'for help fixing the issue')
-
-            if self.map_uploader_task.error_string:
-                error_message += '<p><b>{}</b></p>'.format(
-                    self.map_uploader_task.error_string
+            if self.map_uploader_task.paid_plan_error:
+                error_message = self.tr(
+                    "Uploading files to Felt requires a paid plan, please visit "
+                    "<a href='https://felt.com/pricing'>felt.com/pricing</a> or contact "
+                    "<a href='mailto:sales@felt.com'>sales@felt.com</a>."
                 )
+            else:
+                error_message = \
+                    self.tr('There was an error uploading this file, please '
+                            'contact <a href="mailto:support@felt.com">'
+                            'support@felt.com</a> '
+                            'for help fixing the issue')
+
+                if self.map_uploader_task.error_string:
+                    error_message += '<p><b>{}</b></p>'.format(
+                        self.map_uploader_task.error_string
+                    )
 
             self.progress_label.setText(
                 GuiUtils.set_link_color(


### PR DESCRIPTION
Since Felt changed to requiring a paid plan for all data uploads, QGIS users on free accounts have been receiving a very generic "an error occurred" message when they try to upload and get a 403.

This PR watches for 403's and reports a specific error message.