### PR TITLE
Security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-06-17
+
+- Fix QGIS plugin repository security scan issues blocking release:
+  add an explicit timeout to the OAuth callback unblock request, and
+  replace the high-entropy multipart form boundary with a readable
+  constant
+
 ## [3.2.0] - 2026-06-17
 
 - Add support for QGIS 4.x (Qt6-based) releases, while remaining

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,21 +11,27 @@ published, the [`release.yml`](.github/workflows/release.yml) workflow runs
 `felt/metadata.txt` `version=` field — overriding whatever value is committed
 there.
 
-- Tags use **no `v` prefix** (e.g. `3.2.0`, not `v3.2.0`). The tag name becomes
+- Tags use **no `v` prefix** (e.g. `3.2.1`, not `v3.2.1`). The tag name becomes
   the version string verbatim, so a `v` prefix would ship a version literally
-  named `v3.2.0`.
-- The `version=` field in `felt/metadata.txt` and the entries in
-  `CHANGELOG.md` are cosmetic — they do not drive the release and are not
-  prominently surfaced to users. Keep them consistent for hygiene, but the tag
-  is what matters.
+  named `v3.2.1`.
+- The `version=` field in `felt/metadata.txt` is **cosmetic** — `qgis-plugin-ci`
+  overrides it with the tag name at release time. Keep it consistent with the
+  tag for hygiene, but the tag is what determines the shipped version.
+- `CHANGELOG.md` is **not** cosmetic. At release time `qgis-plugin-ci` reads it
+  and injects the matching version's notes into the packaged `metadata.txt`
+  `changelog=` field, which QGIS surfaces to users in the Plugin Manager. So the
+  `changelog=` field in `metadata.txt` is intentionally left empty and must not
+  be hand-edited — maintain release notes in `CHANGELOG.md` only.
 
 ## Steps
 
-1. **(Optional) Update the changelog and metadata on a branch.** Move items out
-   of `[Unreleased]` in `CHANGELOG.md` into a new `## [<version>] - <date>`
-   section, and bump `version=` in `felt/metadata.txt` to match. Open a PR and
-   merge to `main`. This is cosmetic hygiene, not required for the release to
-   succeed.
+1. **Update the changelog and metadata on a branch.** Move items out of
+   `[Unreleased]` in `CHANGELOG.md` into a new `## [<version>] - <date>` section,
+   and bump `version=` in `felt/metadata.txt` to match. Open a PR and merge to
+   `main`. The release will still build without this, but the `CHANGELOG.md`
+   entry is what populates the user-visible changelog in the published package
+   (see Versioning above), so do it before tagging. The `version=` bump itself is
+   cosmetic hygiene since the tag overrides it.
 
 2. **Create a GitHub Release** with a new tag (e.g. `3.2.0`), targeting `main`.
    Publishing the release triggers [`release.yml`](.github/workflows/release.yml),
@@ -47,3 +53,10 @@ there.
   builds an `-alpha` package via `qgis-plugin-ci package` and uploads it as a CI
   artifact (with a download link posted on the PR). This is for testing
   pre-release builds and is not part of the release path.
+- **If plugins.qgis.org rejects the upload** (e.g. its automated security scan
+  blocks the package), do **not** reuse the same version number to resubmit.
+  The GitHub tag/release for that version is already cut against the old code
+  and should be treated as immutable. Fix the issues on a branch, bump to a new
+  patch version (e.g. `3.2.0` → `3.2.1`) with a matching `CHANGELOG.md` entry,
+  cut a new tag/release, and upload that. Leave the blocked release in place as
+  a record of the attempt.

--- a/felt/core/api_client.py
+++ b/felt/core/api_client.py
@@ -72,6 +72,9 @@ class FeltApiClient:
     UPDATE_LAYER_ENDPOINT = '/maps/{}/layers'
     LAYER_GROUPS_ENDPOINT = '/maps/{}/layer_groups'
 
+    # boundary marker used when building multipart/form-data upload bodies
+    MULTIPART_BOUNDARY = 'QGISFeltPluginFormBoundary'
+
     def __init__(self):
         # default headers to add to all requests
         self.headers = {
@@ -338,15 +341,19 @@ class FeltApiClient:
             b'Host',
             parameters.url[len('https://'):-1].encode()
         )
+        boundary = self.MULTIPART_BOUNDARY
         network_request.setRawHeader(
             b"Content-Type",
-            b"multipart/form-data; boundary=QGISFormBoundary2XCkqVRLJ5XMxfw5")
+            "multipart/form-data; boundary={}".format(boundary).encode())
+
+        delimiter = "--{}\r\n".format(boundary).encode()
+        closing_delimiter = "--{}--\r\n".format(boundary).encode()
 
         # build the form content as bytes: PyQt6 does not permit appending
         # strings to QByteArray
         form_content = b''
         for name, value in parameters.to_form_fields().items():
-            form_content += b"--QGISFormBoundary2XCkqVRLJ5XMxfw5\r\n"
+            form_content += delimiter
             form_content += b"Content-Disposition: form-data; "
             form_content += f"name=\"{name}\"".encode()
             form_content += b"\r\n"
@@ -354,7 +361,7 @@ class FeltApiClient:
             form_content += str(value).encode()
             form_content += b"\r\n"
 
-        form_content += b"--QGISFormBoundary2XCkqVRLJ5XMxfw5\r\n"
+        form_content += delimiter
         form_content += b"Content-Disposition: "
         form_content += \
             f"form-data; name=\"file\"; filename=\"{filename}\"\r\n".encode()
@@ -364,7 +371,7 @@ class FeltApiClient:
         form_content += content
 
         form_content += b"\r\n"
-        form_content += b"--QGISFormBoundary2XCkqVRLJ5XMxfw5--\r\n"
+        form_content += closing_delimiter
 
         form_data = QByteArray(form_content)
         content_length = form_data.length()

--- a/felt/core/auth.py
+++ b/felt/core/auth.py
@@ -181,9 +181,10 @@ class OAuthWorkflow(QThread):
         """
         # we have to dummy a dummy request in order to abort the
         # blocking handle_request() loop
-        # pylint: disable=missing-timeout
-        requests.get("http://127.0.0.1:{}".format(REDIRECT_PORT))
-        # pylint: enable=missing-timeout
+        requests.get(
+            "http://127.0.0.1:{}".format(REDIRECT_PORT),
+            timeout=10
+        )
 
     def close_server(self):
         """

--- a/felt/metadata.txt
+++ b/felt/metadata.txt
@@ -24,7 +24,9 @@ repository=https://github.com/felt/qgis-plugin
 
 # Recommended items:
 
-# Uncomment the following line and add your changelog:
+# Leave this empty. The changelog is maintained in CHANGELOG.md and
+# injected here automatically by qgis-plugin-ci at release time
+# (see .github/workflows/release.yml). Do not edit this field by hand.
 changelog=
 
 # Tags are comma separated with spaces allowed

--- a/felt/metadata.txt
+++ b/felt/metadata.txt
@@ -12,7 +12,7 @@ name=Add to Felt
 qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 description=Create a collaborative Felt (felt.com) map from QGIS
-version=3.2.0
+version=3.2.1
 author=Felt
 email=support@felt.com
 

--- a/felt/test/test_api_client.py
+++ b/felt/test/test_api_client.py
@@ -277,7 +277,7 @@ class ApiClientTest(unittest.TestCase):
             b'form-data; name="file"; filename="test.gpkg"', body)
         self.assertIn(b'GPKG\x00\x01binary', body)
         self.assertTrue(
-            body.endswith(b'--QGISFormBoundary2XCkqVRLJ5XMxfw5--\r\n'))
+            body.endswith(b'--QGISFeltPluginFormBoundary--\r\n'))
         self.assertEqual(request.rawHeader(b'Content-Length'),
                          str(len(body)).encode())
 


### PR DESCRIPTION
Fixes two "critical" issues flagged by the QGIS plugin repository security scan that were blocking the v3.2.0 release.

Bumps to v3.2.1.

### Security scan findings

**Bandit Security Analysis**
- `felt/core/auth.py:185` — Call to `requests` without timeout

**Secrets Detection**
- `felt/core/api_client.py:349` — Potential Base64 High Entropy String detected
- `felt/core/api_client.py:367` — Potential Base64 High Entropy String detected

#### Note on severity

The QGIS plugin scan labels these "critical," but that reflects the scanner's default tags, not real-world impact in this plugin:

- **Secrets Detection (`api_client.py`)** — False positive. The flagged string was a `multipart/form-data` boundary marker (a public, plaintext HTTP delimiter, identical for every user), not a credential. Nothing to leak; the change is cosmetic to satisfy the scanner's entropy heuristic.
- **Bandit, `requests` without timeout (`auth.py`)** — A legitimate best-practice fix, but low severity here: the call targets `127.0.0.1` against a server the plugin itself just started, with no untrusted input or remote attacker. Worst case is a hung thread (reliability/UX), not an exploitable vulnerability.

Both are fixed because the scan is a binary publication gate on plugins.qgis.org, and both changes are harmless-to-positive regardless. Users of 3.2.0 were not realistically at risk.

### Changes

- **Add timeout to OAuth callback unblock request** (`auth.py`) — The `requests.get()` call that unblocks the local OAuth callback server's `handle_request()` loop had no
timeout (the warning was previously suppressed with a `missing-timeout` pylint pragma). Added an explicit `timeout=10` and removed the now-unneeded pragma. Behavior is
unchanged on the normal localhost path and strictly safer in the edge case (bounded wait instead of an indefinite hang).

- **Replace high-entropy multipart boundary with a readable constant** (`api_client.py`) — The hardcoded `multipart/form-data` boundary `QGISFormBoundary2XCkqVRLJ5XMxfw5`
tripped the secrets scanner's base64 high-entropy heuristic, though it was only a MIME boundary marker, not a secret. Replaced it with a single low-entropy, readable constant
(`MULTIPART_BOUNDARY = "QGISFeltPluginFormBoundary"`) referenced everywhere the boundary is used, and updated the matching test assertion.

### Notes

- No functional/behavioral change to the OAuth flow or file-upload requests.
- Also includes updates to metadata and releasing docs to clarify use of `changelog` and what to do in the event of a blocked release submission

### Test plan

CI